### PR TITLE
docs: fix deployment platform references from Netlify to Cloudflare Pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ This is a static blog built with **React Router v7** that pre-renders to static 
 - Uses React Router's static prerendering (`ssr: false` in react-router.config.ts)
 - Routes are pre-rendered at build time based on `prerender()` function exports
 - RSS feed and sitemap are generated via build scripts (`scripts/generate-*.ts`)
-- `_redirects` and `_headers` files are copied to output for Netlify
+- `_redirects` and `_headers` files are copied to output for Cloudflare Pages
 
 ### Styling & Theming
 - Tailwind CSS for styling with custom global styles in `styles/`

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ The site is deployed to Cloudflare Pages via GitHub integration. The build comma
 3. RSS feed generation
 4. Static asset copying
 
-The `_headers` and `_redirects` files provide Netlify-compatible configuration for enhanced compatibility.
+The `_headers` and `_redirects` files configure redirects and security headers for Cloudflare Pages.


### PR DESCRIPTION
## Summary

Addresses misleading deployment platform references identified in PR #28's code review.

## Changes

- Update README.md to clarify `_headers` and `_redirects` are for Cloudflare Pages
- Update CLAUDE.md to reflect Cloudflare Pages deployment
- Remove misleading "Netlify-compatible" language

## Context

This PR corrects documentation that incorrectly referenced Netlify when the site is actually deployed to Cloudflare Pages. The `_headers` and `_redirects` files are native Cloudflare Pages configuration files, not Netlify-compatibility shims.

Related: #28

---

Generated with [Claude Code](https://claude.ai/code)