### PR TITLE
Publish air-gapped WebRTC article and translations

### DIFF
--- a/data/blog/air-gapped-webrtc-breaking-the-qr-limit.ca.mdx
+++ b/data/blog/air-gapped-webrtc-breaking-the-qr-limit.ca.mdx
@@ -2,7 +2,6 @@
 title: "Trencant el límit del QR: El descobriment d'un protocol WebRTC sense servidor"
 date: "2026-01-19"
 spoiler: Una simple petició d'un usuari va portar a una sessió intensiva de disseny de protocols assistida per IA. Vaig reduir la senyalització WebRTC de 2.500 bytes a 55 bytes—una reducció del 97,79%—qüestionant cada bona pràctica. Aquesta és la història de com va néixer QWBP.
-draft: true
 tags:
   - javascript
   - webrtc

--- a/data/blog/air-gapped-webrtc-breaking-the-qr-limit.es.mdx
+++ b/data/blog/air-gapped-webrtc-breaking-the-qr-limit.es.mdx
@@ -2,7 +2,6 @@
 title: "Rompiendo el límite del QR: El descubrimiento de un protocolo WebRTC sin servidor"
 date: "2026-01-19"
 spoiler: Una simple petición de un usuario llevó a una sesión intensiva de diseño de protocolos asistida por IA. Reduje la señalización WebRTC de 2.500 bytes a 55 bytes—una reducción del 97,79%—cuestionando cada buena práctica. Esta es la historia de cómo nació QWBP.
-draft: true
 tags:
   - javascript
   - webrtc

--- a/data/blog/air-gapped-webrtc-breaking-the-qr-limit.mdx
+++ b/data/blog/air-gapped-webrtc-breaking-the-qr-limit.mdx
@@ -2,7 +2,6 @@
 title: "Breaking the QR Limit: The Discovery of a Serverless WebRTC Protocol"
 date: "2026-01-19"
 spoiler: A user's simple request led to an intensive AI-assisted protocol design session. I shrunk WebRTC signaling from 2,500 bytes to 55 bytes—a 97.79% reduction—by questioning every best practice. This is the story of how QWBP was born.
-draft: true
 tags:
   - javascript
   - webrtc


### PR DESCRIPTION
Remove draft status from the Breaking the QR Limit article in all three languages (English, Spanish, and Catalan) to make them publicly visible on the blog.