### PR TITLE
chore: reschedule posts from 2026-01-23 to 2026-01-25

### DIFF
--- a/data/blog/when-ai-made-building-cheaper-than-the-meetings-to-plan-it.ca.mdx
+++ b/data/blog/when-ai-made-building-cheaper-than-the-meetings-to-plan-it.ca.mdx
@@ -2,7 +2,7 @@
 title:
   "Quan la IA va Fer que Construir Fos Més Barat que les Reunions per
   Planificar-ho"
-date: "2026-01-23"
+date: "2026-01-25"
 spoiler:
   Vam debatre una funcionalitat durant setmanes. Després algú la va construir en
   un dia amb IA. Quan l'execució costa menys que la coordinació, les reunions es

--- a/data/blog/when-ai-made-building-cheaper-than-the-meetings-to-plan-it.es.mdx
+++ b/data/blog/when-ai-made-building-cheaper-than-the-meetings-to-plan-it.es.mdx
@@ -2,7 +2,7 @@
 title:
   "Cuando la IA Hizo que Construir Fuera Más Barato que las Reuniones para
   Planificarlo"
-date: "2026-01-23"
+date: "2026-01-25"
 spoiler:
   Debatimos una funcionalidad durante semanas. Luego alguien la construyó en un
   día con IA. Cuando la ejecución cuesta menos que la coordinación, las

--- a/data/blog/when-ai-made-building-cheaper-than-the-meetings-to-plan-it.mdx
+++ b/data/blog/when-ai-made-building-cheaper-than-the-meetings-to-plan-it.mdx
@@ -1,6 +1,6 @@
 ---
 title: "When AI Made Building Cheaper Than the Meetings to Plan It"
-date: "2026-01-23"
+date: "2026-01-25"
 spoiler:
   We debated a feature for weeks. Then someone built it in a day with AI. When
   execution costs less than coordination, meetings become the bottleneck.

--- a/data/blog/why-public-ai-skills-dont-fit-your-codebase.ca.mdx
+++ b/data/blog/why-public-ai-skills-dont-fit-your-codebase.ca.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Per Què les Skills Públiques d'IA No Encaixen en la teva Base de Codi"
-date: "2026-01-23"
+date: "2026-01-25"
 spoiler:
   Les skills de React de Vercel li diuen a Claude que utilitzi Server
   Components. Nosaltres no utilitzem Server Components. Les skills genèriques

--- a/data/blog/why-public-ai-skills-dont-fit-your-codebase.es.mdx
+++ b/data/blog/why-public-ai-skills-dont-fit-your-codebase.es.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Por Qué las Skills Públicas de IA No Encajan en tu Base de Código"
-date: "2026-01-23"
+date: "2026-01-25"
 spoiler:
   Las skills de React de Vercel le dicen a Claude que use Server Components.
   Nosotros no usamos Server Components. Las skills genéricas de IA producen

--- a/data/blog/why-public-ai-skills-dont-fit-your-codebase.mdx
+++ b/data/blog/why-public-ai-skills-dont-fit-your-codebase.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Why Public AI Skills Don't Fit Your Codebase"
-date: "2026-01-23"
+date: "2026-01-25"
 spoiler:
   Vercel's React skills tell Claude to use Server Components. We don't use
   Server Components. Generic AI skills produce plausible code that doesn't fit


### PR DESCRIPTION
Move both posts to Sunday:
- why-public-ai-skills-dont-fit-your-codebase (en, es, ca)
- when-ai-made-building-cheaper-than-the-meetings-to-plan-it (en, es, ca)